### PR TITLE
Fix unlock of second achievement for each levels

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -425,7 +425,7 @@ MainWindow::AchievementCheck(void)
 		numAchieved++;
 	}
 	if (gDifficulty < DIFFICULTY_CUSTOM && seconds < 50
-		&& !gAchievements[gDifficulty][0])
+		&& !gAchievements[gDifficulty][1])
 	{
 		gAchievements[gDifficulty][1] = true;
 		numAchieved++;


### PR DESCRIPTION
The check for the second level of achievement is wrong, meaning these achievements can’t be unlocked. This fixes https://github.com/HaikuArchives/BeMines/issues/40